### PR TITLE
Fixed issue 24 - debugger was still using the old memory cell

### DIFF
--- a/ToolChain/Debugger/Debugger.py
+++ b/ToolChain/Debugger/Debugger.py
@@ -47,7 +47,7 @@ __author__ = "CSE"
 __copyright__ = "Copyright 2015, CSE"
 __credits__ = ["CSE"]
 __license__ = "GPL"
-__version__ = "2.1"
+__version__ = "2.2"
 __maintainer__ = "CSE"
 __status__ = "Dev"
 
@@ -421,13 +421,13 @@ class Debugger:
             valueString = ""
             # Direct access to _value is to avoid memory protection elements
             if displayFormat == "bin":
-                valueString = bin(memSlice[i]._value)
+                valueString = bin(memSlice[i])
             if displayFormat == "hex":
-                valueString = hex(memSlice[i]._value)
+                valueString = hex(memSlice[i])
             if displayFormat == "dec":
-                valueString = str(memSlice[i]._value)
+                valueString = str(memSlice[i])
             if displayFormat == "char":
-                valueString = chr(memSlice[i]._value)
+                valueString = chr(memSlice[i])
 
             addressString = hex(address + i)
             self.debugLog("{} - {}".format(addressString, valueString,))


### PR DESCRIPTION
Issue https://github.com/CommunicationsSecurityEstablishment/spartacus/issues/24 is because the debugger was still accessing memory using the old MemoryCell interface. This was removed in PR https://github.com/CommunicationsSecurityEstablishment/spartacus/pull/17

Integrating this PR will fix the issue with the "m" command.